### PR TITLE
Always show the navigationBar when user is annotating image

### DIFF
--- a/Example/PinpointKitExample.xcodeproj/project.pbxproj
+++ b/Example/PinpointKitExample.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinpointKitExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,6 +369,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinpointKitExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.Lickability.PinpointKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -661,7 +661,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/PinpointKit/PinpointKit-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/PinpointKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/PinpointKit/PinpointKit.modulemap";
 				PRODUCT_MODULE_NAME = PinpointKit;
@@ -693,7 +693,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/PinpointKit/PinpointKit-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/PinpointKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/PinpointKit/PinpointKit.modulemap";
 				PRODUCT_MODULE_NAME = PinpointKit;
@@ -760,7 +760,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -784,7 +784,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-PinpointKitExample/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-PinpointKitExample/Pods-PinpointKitExample.modulemap";
@@ -819,7 +819,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-PinpointKitExample/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-PinpointKitExample/Pods-PinpointKitExample.modulemap";

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -63,7 +63,7 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         for i in 0..<view.numberOfSegments {
             view.setWidth(54, forSegmentAt: i)
         }
-        
+        let abc = self.interfaceCustomization
         view.addTarget(self, action: #selector(EditImageViewController.toolChanged(_:)), for: .valueChanged)
         
         return view
@@ -74,6 +74,9 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
         
+        imageView.layer.borderColor = UIColor.systemGray.cgColor
+        imageView.layer.borderWidth = 1
+        imageView.layer.cornerRadius = 5
         return imageView
     }()
     
@@ -236,20 +239,14 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
     
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        navigationController?.hidesBarsOnTap = true
-        navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        navigationController?.hidesBarsOnTap = true
     }
     
     open override func viewDidLayoutSubviews() {
@@ -259,10 +256,6 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
             rect.size.height -= height
             annotationsView.accessibilityFrame = rect
         }
-    }
-    
-    open override var prefersStatusBarHidden: Bool {
-        return true
     }
     
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -317,16 +310,20 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
     // MARK: - Private
     
     private func setupConstraints() {
-        let views = [
-            "imageView": imageView,
-            "annotationsView": annotationsView
-        ]
-        
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|[imageView]|", options: [], metrics: nil, views: views))
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "|[annotationsView]|", options: [], metrics: nil, views: views))
-        
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[imageView]|", options: [], metrics: nil, views: views))
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[annotationsView]|", options: [], metrics: nil, views: views))
+        let safe = view.safeAreaLayoutGuide
+        let screenSize = UIScreen.main.bounds.size
+        let screenRatio = screenSize.width / screenSize.height
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: safe.topAnchor, constant: 20),
+            imageView.bottomAnchor.constraint(equalTo: safe.bottomAnchor, constant: -10),
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: screenRatio),
+            imageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            
+            annotationsView.leftAnchor.constraint(equalTo: imageView.leftAnchor),
+            annotationsView.rightAnchor.constraint(equalTo: imageView.rightAnchor),
+            annotationsView.topAnchor.constraint(equalTo: imageView.topAnchor),
+            annotationsView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor)
+        ])
     }
     
     @objc private func doneButtonTapped(_ button: UIBarButtonItem) {


### PR DESCRIPTION
Closes #

## What It Does
Screenshot and navigation bar are fully visible at once (no tap to hide navigationBar)
## How to Test

## Notes
