### PR TITLE
Editor delegate call when viewDidDisappear

### DIFF
--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditImageViewController.swift
@@ -245,8 +245,11 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         super.viewDidAppear(animated)
     }
     
-    open override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        let screenshot = self.view.imageSnapshotCroppedToFrame(self.imageView.frame)
+        delegate?.editorDidDisappear(self, with: screenshot)
     }
     
     open override func viewDidLayoutSubviews() {
@@ -300,10 +303,7 @@ open class EditImageViewController: UIViewController, UIGestureRecognizerDelegat
         if delegate.editorShouldDismiss(self, with: screenshot) {
             delegate.editorWillDismiss(self, with: screenshot)
             
-            dismiss(animated: animated) { [weak self] in
-                guard let strongSelf = self else { return }
-                delegate.editorDidDismiss(strongSelf, with: screenshot)
-            }
+            dismiss(animated: animated)
         }
     }
     

--- a/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
+++ b/PinpointKit/PinpointKit/Sources/Core/Editing/EditorDelegate.swift
@@ -58,7 +58,7 @@ public protocol EditorDelegate: class {
      
      - note: The default implementation of this method does nothing.
      */
-    func editorDidDismiss(_ editor: Editor, with screenshot: UIImage)
+    func editorDidDisappear(_ editor: Editor, with screenshot: UIImage)
 }
 
 /// Extends `EditorDelegate` with base implementation for functions.
@@ -76,11 +76,11 @@ extension EditorDelegate {
         return true
     }
     
-    func editorWillDismiss(_ editor: Editor, with screenshot: UIImage) {
+    public func editorWillDismiss(_ editor: Editor, with screenshot: UIImage) {
         // Do nothing
     }
     
-    public func editorDidDismiss(_ editor: Editor, with screenshot: UIImage) {
+    public func editorDidDisappear(_ editor: Editor, with screenshot: UIImage) {
         // Do nothing
     }
 }


### PR DESCRIPTION
Closes #

## What It Does
Fixes delegates calls from editor (viewDidDisappear) to get screenshot from annotated imageView.
## How to Test

## Notes
